### PR TITLE
Automatically determine the Docker API version to use

### DIFF
--- a/docker_custodian/docker_autostop.py
+++ b/docker_custodian/docker_autostop.py
@@ -66,7 +66,7 @@ def main():
         stream=sys.stdout)
 
     opts = get_opts()
-    client = docker.Client(timeout=opts.timeout)
+    client = docker.Client(version='auto', timeout=opts.timeout)
 
     matcher = build_container_matcher(opts.prefix)
     stop_containers(client, opts.max_run_time, matcher, opts.dry_run)

--- a/docker_custodian/docker_gc.py
+++ b/docker_custodian/docker_gc.py
@@ -170,7 +170,7 @@ def main():
         stream=sys.stdout)
 
     args = get_args()
-    client = docker.Client(timeout=args.timeout)
+    client = docker.Client(version='auto', timeout=args.timeout)
 
     if args.max_container_age:
         cleanup_containers(client, args.max_container_age, args.dry_run)


### PR DESCRIPTION
This change allows docker-custodian to interact with any Docker server version.