### PR TITLE
Upgrade requirements to fix #17

### DIFF
--- a/docker_custodian/__about__.py
+++ b/docker_custodian/__about__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf8 -*-
 
-__version_info__ = (0, 5, 0)
+__version_info__ = (0, 5, 1)
 __version__ = '%d.%d.%d' % __version_info__

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 argparse==1.3.0
 backports.ssl-match-hostname==3.4.0.2
-docker-py==0.6.0
+docker-py==1.4.0
 future==0.14.3
 python-dateutil==2.4.0
 pytimeparse==1.1.2
-requests==2.5.1
+requests==2.7.0
 six==1.9.0
-websocket-client==0.23.0
+websocket-client==0.32.0

--- a/tests/docker_autostop_test.py
+++ b/tests/docker_autostop_test.py
@@ -53,7 +53,9 @@ def test_has_been_running_since_false(container, earlier_time):
             autospec=True)
 @mock.patch('docker_custodian.docker_autostop.get_opts',
             autospec=True)
-def test_main(mock_get_opts, mock_stop_containers, mock_build_matcher):
+@mock.patch('docker_custodian.docker_autostop.docker', autospec=True)
+def test_main(mock_docker, mock_get_opts, mock_stop_containers, mock_build_matcher):
+    mock_get_opts.return_value.timeout = 30
     main()
     mock_get_opts.assert_called_once_with()
     mock_build_matcher.assert_called_once_with(


### PR DESCRIPTION
Fixes #17 

Bumped version to 0.5.1, please tag after merge


The version of docker-py we were using didn't support `version='auto'` which caused the urls to include the string "auto" as the version (resulting in a 404).