### PR TITLE
added instruction for the pip module of ansible

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,11 @@ Source
 
     pip install git+https://github.com/Yelp/docker-custodian.git
 
+If you are using the pip module of ansible:
+
+.. code:: sh
+
+    pip: name='git+https://github.com/Yelp/docker-custodian.git#egg=docker_custodian'
 
 dcgc
 ----


### PR DESCRIPTION
Ommiting the #egg causes an error in ansible.