### PR TITLE
Don't remove recently created containers that were never used

### DIFF
--- a/docker_custodian/args.py
+++ b/docker_custodian/args.py
@@ -5,7 +5,7 @@ from pytimeparse import timeparse
 
 
 def timedelta_type(value):
-    """Retrun the :class:`datetime.datetime.DateTime` for a time in the past.
+    """Return the :class:`datetime.datetime.DateTime` for a time in the past.
 
     :param value: a string containing a time format supported by :mod:`pytimeparse`
     """


### PR DESCRIPTION
Fixes bug where a container that was never started and is not old was getting removed.