### PR TITLE
recently used image filtering support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,8 @@ install:
 - pip install tox
 script:
 - tox
+
+# we need docker to be running
+sudo: required
+services:
+  - docker

--- a/docker_custodian/__about__.py
+++ b/docker_custodian/__about__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf8 -*-
 
-__version_info__ = (0, 6, 0)
+__version_info__ = (0, 7, 0)
 __version__ = '%d.%d.%d' % __version_info__


### PR DESCRIPTION
This prevents gcdc from deleting images that were built long ago, but we pulled just now.

Currently gcdc is causing some images to be deleted between a pull and run that are only ten seconds apart.