### PR TITLE
Bump debian version to 0.6.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+docker-custodian (0.6.0) lucid; urgency=low
+
+  * Remove python 2.6 support
+  * Remove argparse
+
+ -- Daniel Hoherd <hoherd@yelp.com>  Fri, 24 Jun 2016 13:55:49 -0700
+
 docker-custodian (0.5.3) lucid; urgency=low
 
   * Update docker-py


### PR DESCRIPTION
This bumps the debian package version to 0.6.0 to match the version reported by Python.

https://github.com/Yelp/docker-custodian/commit/f33f0b4b830#diff-4768c808611349a494c75888535bf306L3