### PR TITLE
Do not force people to install python2.7

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Daniel Nephin <dnephin@yelp.com>
 Build-Depends:
     dh-virtualenv,
 
-Depends: python2.7
+Depends: ${python:Depends}, ${shlibs:Depends}, ${misc:Depends}
 Package: docker-custodian
 Architecture: any
 Description: Remove old Docker containers and images that are no longer in use

--- a/debian/rules
+++ b/debian/rules
@@ -2,12 +2,14 @@
 # -*- makefile -*-
 
 export DH_OPTIONS
+PYTHON_BINARY := $(shell { command -v python3.4 || command -v python3.3 || command -v python2.7; } 2>/dev/null)
+PYTHON_PACKAGE := $(lastword $(subst /, ,${PYTHON_BINARY}))
 
 %:
 	dh $@ --with python-virtualenv
 
 override_dh_virtualenv:
-	dh_virtualenv --python python2.7
+	dh_virtualenv --python ${PYTHON_BINARY}
 
 # do not call `make clean` as part of packaging
 override_dh_auto_clean:
@@ -19,3 +21,6 @@ override_dh_auto_build:
 
 override_dh_auto_test:
 	true
+
+override_dh_gencontrol:
+	dh_gencontrol -- -Vpython:Depends="${PYTHON_PACKAGE}"


### PR DESCRIPTION
... use any available and compatible version instead.
If several python versions are available, the highest one will be used.

```
Depends: python3.4, libc6 (>= X.XX), libexpat1 (>= X.XX.X), libsslX.X.X (>= X.X.X), zlib1g (>= X:X.X.X)
```