### PR TITLE
Add patterns support for exclude-image-file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,13 @@ being removed.
         Path to a file which contains a list of images to exclude, one
         image tag per line.
 
+You also can use basic pattern matching to exclude images with generic tags.
 
+.. code::
+
+    user/repositoryA:*
+    user/repositoryB:?.?
+    user/repositoryC-*:tag
 
 dcstop
 ------

--- a/docker_custodian/docker_gc.py
+++ b/docker_custodian/docker_gc.py
@@ -4,6 +4,7 @@ Remove old docker containers and images that are no longer in use.
 
 """
 import argparse
+import fnmatch
 import logging
 import sys
 
@@ -88,7 +89,10 @@ def filter_excluded_images(images, exclude_set):
         image_tags = image_summary.get('RepoTags')
         if no_image_tags(image_tags):
             return True
-        return not set(image_tags) & exclude_set
+        for exclude_pattern in exclude_set:
+            if fnmatch.filter(image_tags, exclude_pattern):
+                return False
+        return True
 
     return filter(include_image, images)
 

--- a/tests/docker_gc_test.py
+++ b/tests/docker_gc_test.py
@@ -177,6 +177,47 @@ def test_filter_excluded_images():
     assert list(actual) == expected
 
 
+def test_filter_excluded_images_advanced():
+    exclude_set = set([
+        'user/one:*',
+        'user/foo:tag*',
+        'user/repo-*:tag',
+    ])
+    images = [
+            {
+                'RepoTags': ['<none>:<none>'],
+                'Id': 'babababababaabababab'
+            },
+            {
+                'RepoTags': ['user/one:latest', 'user/one:abcd']
+            },
+            {
+                'RepoTags': ['user/foo:test']
+            },
+            {
+                'RepoTags': ['user/foo:tag123']
+            },
+            {
+                'RepoTags': ['user/repo-1:tag']
+            },
+            {
+                'RepoTags': ['user/repo-2:tag']
+            },
+
+    ]
+    expected = [
+            {
+                'RepoTags': ['<none>:<none>'],
+                'Id': 'babababababaabababab'
+            },
+            {
+                'RepoTags': ['user/foo:test'],
+            },
+    ]
+    actual = docker_gc.filter_excluded_images(images, exclude_set)
+    assert list(actual) == expected
+
+
 def test_is_image_old(image, now):
     assert docker_gc.is_image_old(image, now)
 


### PR DESCRIPTION
Adding patterns support to exclude images: sometimes you have to exclude some images with generic tags, or images with generic names formed in some specific way. Looks like using regexes here is an overkill, but unix basic pattern matching should fit.

Review, please, and let me know if it can be improved.