### PR TITLE
Fix broken filtering for images used by containers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,4 +48,6 @@ def later_time():
 
 @pytest.fixture
 def mock_client():
-    return mock.create_autospec(docker.Client)
+    client = mock.create_autospec(docker.Client)
+    client._version = '1.17'
+    return client


### PR DESCRIPTION
Fixes errors like this:

```
Error calling remove_image image=xxx:latest 409 Client Error: Conflict ("conflict: unable to remove repository reference "xxx:latest" (must force) - container 91ab644a7b31 is using its referenced image 7caea3c78386")
```

The error is caused by mismatch between entry in `image_tags_in_use` and tag produced inside [filter_images_in_use](https://github.com/Yelp/docker-custodian/blob/fee79d9e355ff86364d143379ceb0fbf9ad3c8f1/docker_custodian/docker_gc.py#L114)

For in my local tests image used by container without tags and with id 'sha256:ff5f2ec93a207bdf948f986bc94e938977979befedd53121a32e8d74fc58fb8e' produced set `set(['sha256:ff5f2:latest'])` that didn't match with entry from the `image_tags_in_use` which was full image id.

Also see #14