### PR TITLE
Ignore CHANGELOG.md for the end-of-file precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
     - id: check-yaml
     - id: debug-statements
     - id: end-of-file-fixer
+      exclude: CHANGELOG.md
     - id: flake8
     - id: name-tests-test
     - id: requirements-txt-fixer


### PR DESCRIPTION
The changelog autogenerator doesn't seem to add a newline at the end of the file and trips the end-of-file precommit hook.  Add an exclusion for that file