### PR TITLE
Add flag to retain recently used images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 __pycache__
 
 *.egg-info/
+.venv


### PR DESCRIPTION
Recency is derived from docker events with status `create` and `exec_start.*`.