### PR TITLE
Simplify instructions for installing with pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,12 +41,12 @@ Then install it
     dpkg -i ../docker-custodian_*.deb
 
 
-Source
-~~~~~~
+pypi.org
+~~~~~~~~
 
 .. code:: sh
 
-    pip install git+https://github.com/Yelp/docker-custodian.git#egg=docker_custodian
+    pip install docker-custodian
 
 
 dcgc


### PR DESCRIPTION
Since #10, there's no need to use the git URL with pip. Also, this new command installs the latest release instead of the last commit on master, which is probably what most users need.