### PR TITLE
Enable multi-arch builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,65 @@
+---
+name: push-docker-images
+
+"on":
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ github.repository }}
+          flavor: |
+            latest=auto
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: |
+            linux/386
+            linux/amd64
+            linux/arm/v6
+            linux/arm/v7
+            linux/arm64
+            linux/ppc64le
+            linux/s390x
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM    alpine:3.2
-MAINTAINER Kyle Anderson <kwa@yelp.com>
+FROM python:3.9-alpine3.12
 
-RUN     apk add -U python py-pip
-ADD     requirements.txt /code/requirements.txt
-RUN     pip install -r /code/requirements.txt
-ADD     docker_custodian/ /code/docker_custodian/
-ADD     setup.py /code/
-RUN     pip install --no-deps -e /code
+COPY requirements.txt /code/requirements.txt
+RUN pip install -r /code/requirements.txt
+COPY docker_custodian/ /code/docker_custodian/
+COPY setup.py /code/
+RUN pip install --no-deps -e /code
+
+ENTRYPOINT ["dcgc"]

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Container
     docker pull yelp/docker-custodian
     docker run -ti \
         -v /var/run/docker.sock:/var/run/docker.sock \
-        yelp/docker-custodian dcgc --help
+        yelp/docker-custodian --help
 
 Debian/Ubuntu package
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This branch adds multi-arch builds using GitHub actions and pushing to Docker Hub.

In addition to adding the GitHub workflow, it updates the Docker base image to one that has multiple architectures in the manifest. It also includes a small change of adding an entrypoint to the image. I'd be fine backing that change out, but it does simplify usage. A tag is required to push a new `latest` and version tagged image.

You can see the results of this build on https://hub.docker.com/r/vividboarder/docker-custodian/tags