### PR TITLE
Remove pre-commit autoupdate in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,4 @@ deps =
     pytest
 commands =
     py.test {posargs:tests}
-    pre-commit autoupdate
-    pre-commit install -f --install-hooks
     pre-commit run --all-files


### PR DESCRIPTION
The autoupdate command caused failures when some hooks get updated.
These are expected to be version pinned and auto updating them means we
can't ensure a stable build. Removing this from tox won't prevent us
from manually updating our hooks periodically.